### PR TITLE
update Dockerfile to use node:18-bookworm-slim base image

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 ARBITRUM_RPC_URLS=https://arbitrum-sepolia-rpc.publicnode.com,https://arbitrum-sepolia.drpc.org,https://sepolia-rollup.arbitrum.io/rpc,https://public.stackup.sh/api/v1/node/arbitrum-sepolia
 ARBITRUM_FORK_RPC_URL=https://arbitrum-sepolia-rpc.publicnode.com
 BSC_TESTNET_RPC_URLS=https://bsc-testnet-dataseed.bnbchain.org
-BSC_TESTNET_FORK_RPC_URL=https://bsc-testnet-dataseed.bnbchain.org
+BSC_TESTNET_FORK_RPC_URLS=https://bsc-testnet-dataseed.bnbchain.org
 BERACHAIN_RPC_URLS=https://bepolia.rpc.berachain.com/
 BERACHAIN_FORK_RPC_URL=https://bepolia.rpc.berachain.com/
 REDIS_PASSWORD=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ version: '3.8'
 x-common-environment: &common-environment
   NODE_ENV: production
   RPC_URLS: ${RPC_URLS}
+  BSC_TESTNET_RPC_URLS: ${BSC_TESTNET_RPC_URLS}
+  BSC_TESTNET_FORK_RPC_URLS: ${BSC_TESTNET_FORK_RPC_URLS}
   REDIS_HOST: redis-server
   REDIS_PASSWORD: ${REDIS_PASSWORD}
 

--- a/packages/collector/.env.example
+++ b/packages/collector/.env.example
@@ -1,7 +1,7 @@
 ARBITRUM_RPC_URLS=https://arbitrum-sepolia-rpc.publicnode.com
 ARBITRUM_FORK_RPC_URL=https://arbitrum-sepolia-rpc.publicnode.com
 BSC_TESTNET_RPC_URLS=https://bsc-testnet-dataseed.bnbchain.org
-BSC_TESTNET_FORK_RPC_URL=https://bsc-testnet-dataseed.bnbchain.org
+BSC_TESTNET_FORK_RPC_URLS=https://bsc-testnet-dataseed.bnbchain.org
 BERACHAIN_RPC_URLS=https://bepolia.rpc.berachain.com/
 BERACHAIN_FORK_RPC_URL=https://bepolia.rpc.berachain.com/
 REDIS_PASSWORD=

--- a/packages/collector/Dockerfile
+++ b/packages/collector/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-bullseye-slim
+FROM node:18-bookworm-slim
 
 # Create directory to install Foundry
 WORKDIR /root

--- a/packages/collector/src/constants.ts
+++ b/packages/collector/src/constants.ts
@@ -163,8 +163,8 @@ export const networksConfig: Record<Networks, NetworksConfig> = {
     useFork: false,
   },
   [Networks.BSC_TESTNET]: {
-    rpc_url: process.env.BSC_TESTNET_RPC_URL?.split(',')[0] || 'https://bsc-testnet-dataseed.bnbchain.org',
-    fork_rpc_url: process.env.BSC_TESTNET_FORK_RPC_URL?.split(',')[0] || 'https://bsc-testnet-dataseed.bnbchain.org',
+    rpc_url: process.env.BSC_TESTNET_RPC_URLS?.split(',')[0] || 'https://bsc-testnet-dataseed.bnbchain.org',
+    fork_rpc_url: process.env.BSC_TESTNET_FORK_RPC_URLS?.split(',')[0] || 'https://bsc-testnet-dataseed.bnbchain.org',
     markets: {
       'Counter-Strike 2 Skins': {
         address: '0xE886b759c7811052EF54CCbC7359766A134211fb',

--- a/packages/executor/src/constants.ts
+++ b/packages/executor/src/constants.ts
@@ -29,7 +29,7 @@ export const networksConfig: Record<Networks, NetworksConfig> = {
     rpc_url: process.env.BERACHAIN_RPC_URLS?.split(',')[0] || 'https://bepolia.rpc.berachain.com/',
   },
   [Networks.BSC_TESTNET]: {
-    rpc_url: process.env.BSC_TESTNET_RPC_URL?.split(',')[0] || 'https://bsc-testnet-dataseed.bnbchain.org',
+    rpc_url: process.env.BSC_TESTNET_RPC_URLS?.split(',')[0] || 'https://bsc-testnet-dataseed.bnbchain.org',
     useOldMarketAbi: true,
   },
 }

--- a/packages/liquidation-checker/src/config.ts
+++ b/packages/liquidation-checker/src/config.ts
@@ -36,7 +36,7 @@ export const networkConfig: Record<Networks, NetworkConfig> = {
     rpc_first_probability: 1,
   },
   [Networks.BSC_TESTNET]: {
-    rpcUrls: process.env.BSC_TESTNET_RPC_URL?.split(',') || ['https://bsc-testnet-dataseed.bnbchain.org'],
+    rpcUrls: process.env.BSC_TESTNET_RPC_URLS?.split(',') || ['https://bsc-testnet-dataseed.bnbchain.org'],
     multicall2_address: '0xca11bde05977b3631167028862be2a173976ca11',
     ovl_state_address: '0x81BdBf6C69882Fe7c958018D3fF7FcAcb59EF8b7',
     multicall_batch_size: 300,


### PR DESCRIPTION
fixing error:
```
------
 > [collector  6/16] RUN forge --version:
0.360 forge: /lib/x86_64-linux-gnu/libc.so.6: version GLIBC_2.33' not found (required by forge)
0.360 forge: /lib/x86_64-linux-gnu/libc.so.6: version GLIBC_2.32' not found (required by forge)
0.360 forge: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by forge)
------
```